### PR TITLE
Fix filenames generation when saving individual steps

### DIFF
--- a/hiperwalk/plot/_plot.py
+++ b/hiperwalk/plot/_plot.py
@@ -258,12 +258,9 @@ def plot_probability_distribution(
         # saves or shows image (or both)
         if not animate:
             if filename is not None:
-                # enumarating the plot
-                filename_suffix = (
-                    '-' + (len(probabilities)-1)//10 * '0' + str(i)
-                    if len(probabilities) > 1 else ''
-                )
-                plt.savefig(filename + filename_suffix)
+                # TODO: consider using Python's string formatting operations
+                filename_suffix = str(i).zfill(len(str(len(probabilities))))
+                plt.savefig(filename + '-' + filename_suffix)
                 if not show:
                     plt.close()
             if show:

--- a/hiperwalk/plot/_plot.py
+++ b/hiperwalk/plot/_plot.py
@@ -259,7 +259,7 @@ def plot_probability_distribution(
         if not animate:
             if filename is not None:
                 # TODO: consider using Python's string formatting operations
-                filename_suffix = str(i).zfill(len(str(len(probabilities))))
+                filename_suffix = str(i).zfill(len(str(len(probabilities) - 1)))
                 plt.savefig(filename + '-' + filename_suffix)
                 if not show:
                     plt.close()


### PR DESCRIPTION
This fixes the zero-padding on filenames generated by `plot_probability_distribution()`

----

At the moment, when using something like

```python
hpw.plot_probability_distribution(probs, filename='TEST', show=False)
```

with **11 steps**, the generated files will have the following names:

```
TEST-00.png
TEST-01.png                                                                                                                                                                                                        TEST-02.png     
TEST-03.png
TEST-04.png
TEST-05.png
TEST-06.png                   
TEST-07.png
TEST-08.png
TEST-09.png
TEST-010.png
```

This PR changes this behavior to generate names as following:

```
TEST-00.png
TEST-01.png
TEST-02.png
TEST-03.png
TEST-04.png
TEST-05.png
TEST-06.png
TEST-07.png
TEST-08.png
TEST-09.png
TEST-10.png
```