### PR TITLE
Create logic to draw a GTK4 window with animation

### DIFF
--- a/hiperwalk/plot/__init__.py
+++ b/hiperwalk/plot/__init__.py
@@ -1,7 +1,3 @@
-# Always use Gtk 3.0
-from gi import require_version
-require_version('Gtk', '3.0')
-
 # importing everything under the hood of the
 # hiperwalk.plot package
 from ._plot import *

--- a/hiperwalk/plot/_animation.py
+++ b/hiperwalk/plot/_animation.py
@@ -286,56 +286,26 @@ class Animation:
                 temp.close()
 
         elif Gtk_version == 4:
-            # creating window
-            window = Gtk.ApplicationWindow(title="Animation")
-            state = window.get_state_flags()
-            # window.override_background_color(state, RGBA(1, 1, 1, 1))
 
-            def configure_gif_window(self):
-                pass
+            from ._gtk4_gif_paintable import GifPaintable
 
-            def configure_video_window(self):
-                pass
-
-            if self.save_path[-4:] == '.gif':
-                configure_gif_window(self)
-            else:
-                configure_video_window(self)
-
-            def on_activate(app, save_path):
+            def on_activate(app):
                 win = Gtk.ApplicationWindow(application=app)
-                ############################
-                from gi.repository import GdkPixbuf
-                pixbuf = GdkPixbuf.PixbufAnimation.new_from_file(save_path)
-                img = Gtk.Image()
-                img.set_from_animation(pixbuf)
-                win.set_child(img)
-                win.present()
-                ############################
-                #img = Gtk.Image.new_from_file(save_path)
-                #win.set_child(img)
-                #win.present()
-                ############################
-                #img = Gtk.Video.new_for_filename(save_path)
-                # img = Gtk.Image.new()
-                # Gtk.Image.set_from_file(img, save_path)
-                #img.set_from_file(save_path)
-                ############################
-                #stream = Gtk.MediaFile.new_for_filename(save_path)
-                #video = Gtk.Video.new_for_media_stream(stream)
-                #video.set_autoplay(True)
-                #video.set_hexpand(True)
-                #video.set_vexpand(True)
-                #win.set_child(video)
-                #win.present() 
+                win.set_default_size(400, 300)
+                win.set_title("Animation")
 
-            app = Gtk.Application()
-            app.connect('activate', on_activate, self.save_path)
+                picture = Gtk.Picture()
+                anim = GifPaintable(self.save_path)
+                picture.set_paintable(anim)
+
+                win.set_child(picture)
+
+                win.show()
+
+            app = Gtk.Application(application_id='org.hiperwalk.animation')
+            app.connect('activate', on_activate)
             app.run(None)
-            # showing window and starting Gtk main loop
-            # window.show_all()
-            # Gtk.main()
-            
+
             if temp is not None:
                 self.save_path = None
                 temp.close()

--- a/hiperwalk/plot/_gtk4_gif_paintable.py
+++ b/hiperwalk/plot/_gtk4_gif_paintable.py
@@ -1,0 +1,38 @@
+from gi import require_version
+require_version('Gtk', '4.0')
+from gi.repository import Gtk, GLib, Gdk, GdkPixbuf, GObject
+
+class GifPaintable(GObject.Object, Gdk.Paintable):
+    def __init__(self, path):
+        super().__init__()
+        self.animation = GdkPixbuf.PixbufAnimation.new_from_file(path)
+        self.iterator = self.animation.get_iter()
+        self.delay = self.iterator.get_delay_time()
+        self.timeout = GLib.timeout_add(self.delay, self.on_delay)
+
+        self.invalidate_contents()
+
+    def on_delay(self):
+        delay = self.iterator.get_delay_time()
+        self.timeout = GLib.timeout_add(delay, self.on_delay)
+        self.invalidate_contents()
+
+        return GLib.SOURCE_REMOVE
+
+    def do_get_intrinsic_height(self):
+        return self.animation.get_height()
+
+    def do_get_intrinsic_width(self):
+        return self.animation.get_width()
+
+    def invalidate_contents(self):
+        self.emit("invalidate-contents")
+
+    def do_snapshot(self, snapshot, width, height):
+        timeval = GLib.TimeVal()
+        timeval.tv_usec = GLib.get_real_time()
+        self.iterator.advance(timeval)
+        pixbuf = self.iterator.get_pixbuf()
+        texture = Gdk.Texture.new_for_pixbuf(pixbuf)
+
+        texture.snapshot(snapshot, width, height)


### PR DESCRIPTION
[358fc53](https://github.com/hiperwalk/hiperwalk/commit/358fc53a03e5051dee1c4ebe8ac3d0f13d6c8692) forced the use of GTK 3 for the animation window but had the collateral effect of turning  ```gi``` in a dependency even for users that doesn't desire to visualize animations.

This PR implements the logic to draw the animation window with GTK 4 as well as 3 and make possible to `import` hiperwalk in environments without the ```gi``` package.