### PR TITLE
Make animations work in JupyterLite

### DIFF
--- a/hiperwalk/plot/_plot.py
+++ b/hiperwalk/plot/_plot.py
@@ -313,7 +313,7 @@ def plot_probability_distribution(
                 from IPython import display
 
                 # embedding animation in jupyter notebook
-                video = anim.to_html5_video()
+                video = anim.to_jshtml()
                 html = display.HTML(video)
                 display.display(html)
 
@@ -923,9 +923,14 @@ def _plot_probability_distribution_on_plane(
     return [[surf[0]], cbar]
 
 def _is_in_notebook():
+    ipython_shells = (
+        'XPythonShell',        # jupyterlite-xeus-python
+        'Interpreter',         # jupyterlite-pyodide-kernel
+        'ZMQInteractiveShell', # ipykernel
+    )
     try:
         shell = get_ipython().__class__.__name__
-        if shell == 'ZMQInteractiveShell':
+        if shell in ipython_shells:
             return True
         return False
     except:


### PR DESCRIPTION
This PR makes animations work within JupyterLite environments. We need this to make hiperwalk/hiperwalk.github.io#4 viable.

After merging will be possible to build a JupyterLite website like the one in the video below.

https://github.com/hiperwalk/hiperwalk/assets/973834/36b36794-f71c-4140-b7d8-c9e7f2961786

---

:exclamation: `pyproject.toml` lists `matplotlib>=3.7` as a dependency but [conda-forge](https://repo.mamba.pm/conda-forge) and [emscripten-forge](https://repo.mamba.pm/emscripten-forge) (the preferred way to install packages in a `jupyterlite-xeus-python` kernel at the moment) only have an older version than 3.7 available.

It works anyway because installing dependencies via `pip` is experimental and it doesn't seem to be enforcing package versions checks yet.

```
[LiteBuildApp] WARNING | 
            Installing pip dependencies. This is very much experimental so use this feature at your own risks.
            Note that you can only install pure-python packages.
            pip is being run with the --no-deps option to not pull undesired system-specific dependencies, so please
            install your package dependencies from emscripten-forge or conda-forge.
```

When trying to install a `hiperwalk` wheel in a Pyodide kernel via `micropip.install()` we get an error complaining about the `matplotlib` version:

```
ValueError: Can't find a pure Python 3 wheel for 'matplotlib>=3.7'.
See: https://pyodide.org/en/stable/usage/faq.html#why-can-t-micropip-find-a-pure-python-wheel-for-a-package
You can use `await micropip.install(..., keep_going=True)` to get a list of all packages with missing wheels.
```

I made the choice of **not** downgrading the matplotlib version in `pyproject.toml` since everything seems to be working with the version available on conda-forge in `jupyterlite-xeus-python` and we won't use a Pyodide kernel to embed a [REPL on hiperwalk.org](https://github.com/hiperwalk/hiperwalk.github.io/issues/4).
